### PR TITLE
[Feature] Add more props for TopBar

### DIFF
--- a/libs/mui/src/lib/TopBar/index.stories.tsx
+++ b/libs/mui/src/lib/TopBar/index.stories.tsx
@@ -1,6 +1,8 @@
 import { Meta, Story } from '@storybook/react'
 
-import { TopBar, TopBarProps } from '.'
+import { FiChevronRight } from 'react-icons/fi'
+
+import { TopBar, TopBarActionMode, TopBarProps } from '.'
 
 export default {
   component: TopBar,
@@ -22,4 +24,21 @@ const Template: Story<TopBarProps> = (args) => {
 export const Default = Template.bind({})
 Default.args = {
   title: 'Title',
+}
+
+export const Heading = Template.bind({})
+Heading.args = {
+  title: 'Title',
+  mode: TopBarActionMode.Heading,
+}
+
+export const HeadingWithButton = Template.bind({})
+HeadingWithButton.args = {
+  title: 'Title',
+  mode: TopBarActionMode.Heading,
+  button: {
+    label: 'Button',
+    onClick: () => alert('Clicked'),
+    endIcon: <FiChevronRight />,
+  },
 }

--- a/libs/mui/src/lib/TopBar/index.tsx
+++ b/libs/mui/src/lib/TopBar/index.tsx
@@ -1,4 +1,4 @@
-import { IconButton, Stack, Typography, styled, useTheme } from '@mui/material'
+import { Button, ButtonProps, IconButton, Stack, Typography, styled, useTheme } from '@mui/material'
 import { useRouter } from 'next/router'
 
 import { MouseEventHandler } from 'react'
@@ -18,10 +18,19 @@ export enum TopBarActionType {
   None = 'none',
 }
 
+export enum TopBarActionMode {
+  Normal = 'normal',
+  Heading = 'heading',
+}
+
 export interface TopBarProps {
   title?: string
   action?: TopBarActionType
   onClose?: MouseEventHandler<HTMLButtonElement>
+  mode?: TopBarActionMode
+  button?: ButtonProps & {
+    label: string
+  }
 }
 
 const ActionIcon: React.FC<Pick<TopBarProps, 'action' | 'onClose'>> = ({ action, onClose }) => {
@@ -54,7 +63,24 @@ export const TopBar: React.FC<TopBarProps> = ({
   title,
   action = TopBarActionType.None,
   onClose,
+  mode = TopBarActionMode.Normal,
+  button,
 }) => {
+  if (mode === TopBarActionMode.Heading) {
+    return (
+      <Stack direction="row" justifyContent="space-between" p={1} mb={4}>
+        <Typography variant="title2" color="ink.darkest" fontWeight={400}>
+          {title}
+        </Typography>
+        {button && (
+          <Button color="primary" {...button}>
+            {button.label}
+          </Button>
+        )}
+      </Stack>
+    )
+  }
+
   return (
     <Stack direction="row" justifyContent="center" sx={{ position: 'relative' }} p={1} mb={4}>
       <IconContainer>


### PR DESCRIPTION
## What I do

1. Add `mode` for TopBar 
2. `heading` mode will be something like this

<img width="1679" alt="Screen Shot 2565-02-25 at 22 59 36" src="https://user-images.githubusercontent.com/33742791/155747165-8d4bbc87-d10c-414d-ae9f-edc6d1083f95.png">

4. `heading` mode also accept `button` 
5. with `heading` mode `action` will no longer be used